### PR TITLE
Enable markdown-link-check

### DIFF
--- a/.github/workflows/markdown-links-config.json
+++ b/.github/workflows/markdown-links-config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://sharpavi.codeplex.com/$"
+    }
+  ]
+}

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -15,4 +15,5 @@ jobs:
     - uses: actions/checkout@v3
     - uses: EliahKagan/github-action-markdown-link-check@exclude-dir-experimental
       with:
+        config-file: .github/workflows/markdown-links-config.json
         exclude-dirs: ./docs

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -1,0 +1,18 @@
+name: Check Markdown links
+
+on:
+  push:
+    branches:
+      - net5
+  pull_request:
+  schedule:
+    - cron: '15 0,12 * * *'
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EliahKagan/github-action-markdown-link-check@exclude-dir-experimental
+      with:
+        exclude-dirs: ./docs


### PR DESCRIPTION
I'm not scanning docs/ with it, since I've been preserving that for posterity.

To achieve the exclusion, I'm using my fork of:

https://github.com/marketplace/actions/markdown-link-check

See the committed workflow (markdown-links.yml) for details.