### PR TITLE
Use explicit `contents: read` permissions where applicable

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '15 0,12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There was a GitHub Actions workflow where I had not specified `permissions` explicitly. That falls back to using the repository defaults, which is less clear than specifying them, and also sometimes less secure, if the repository defaults are more expansive than necessary for a workflow. This fixes that.